### PR TITLE
Use . consistently in the feed chain

### DIFF
--- a/lib/Test/Fuzz/Generator.pm6
+++ b/lib/Test/Fuzz/Generator.pm6
@@ -31,7 +31,7 @@ method generate(Int() $size = 100) {
 
 	my %generator
 		<== map({.^name => lazy .generate-samples})
-		<== grep({try {lazy .?generate-samples}})
+		<== grep({try {lazy .generate-samples}})
 		<== @types
 	;
 


### PR DESCRIPTION
Because this happens inside a try block, using . should work just as
good. Ideally it shouldn't matter if . or .? is used, but this call
happens on a subclass of an augmented class (MONKEY-TYPING). There are
some issues¹ in rakudo regarding this particular combination, and
recent attempts to resolve part of the issue (for .? only) resulted in
tests failing in this module. Tests seem to pass regardless of which
op is used (both . and both .? result in green tests), but I suspect
that behavior will be different on (future) rakudo versions where .?
is less buggy. This PR preserves the previous behavior for future
rakudo releases where a fix for .? may be introduced, but please
consider using .? if the right behavior is wanted.

¹ – https://github.com/rakudo/rakudo/issues/1923